### PR TITLE
Fix rust-toolchain file format

### DIFF
--- a/rust-toolchain
+++ b/rust-toolchain
@@ -1,3 +1,1 @@
-[toolchain]
-channel = "1.93"
-profile = "minimal"
+1.93


### PR DESCRIPTION
This PR fixes the rust-toolchain file format.

The previous format was TOML-like but rustup expects a simple channel version string.

Changed from:


To:


This fixes the GitHub Actions Release workflow which was failing with:
error: invalid value '[toolchain]...' for '[TOOLCHAIN]...': invalid toolchain name