### PR TITLE
fix: add permissions for GitHub Actions release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,6 +7,9 @@ on:
     tags:
       - 'v*'
 
+permissions:
+  contents: write
+
 jobs:
   build:
     runs-on: ubuntu-latest


### PR DESCRIPTION
This PR fixes the 403 'Resource not accessible by integration' error that occurs when trying to create releases using softprops/action-gh-release@v2.

Changes:
- Added contents: write permission at the workflow level to grant the GITHUB_TOKEN the necessary permissions to create releases
- The checkout action also needs contents: read permission, which is now explicitly granted

The release workflow will now be able to create releases when tags are pushed.