### PR TITLE
fix: build statically linked binary with musl libc

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,15 +15,17 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: actions-rs/toolchain@v1
-        with:
-          profile: minimal
-      - run: cargo build --release --locked
+      - name: Install musl tools
+        run: sudo apt-get update && sudo apt-get install -y musl-tools
+      - name: Add musl target
+        run: rustup target add x86_64-unknown-linux-musl
+      - name: Build static binary
+        run: cargo build --release --target x86_64-unknown-linux-musl --locked
       - name: Upload binary artifact
         uses: actions/upload-artifact@v4
         with:
           name: release
-          path: target/release/ideavault
+          path: target/x86_64-unknown-linux-musl/release/ideavault
           retention-days: 1
 
   release:
@@ -36,8 +38,8 @@ jobs:
           name: release
           path: target/release/
 
-      - name: Create tar.gz for Linux x86_64
-        run: tar -czf ideavault-x86_64-unknown-linux-gnu.tar.gz -C target/release/ ideavault
+      - name: Create tar.gz for Linux x86_64 (static)
+        run: tar -czf ideavault-x86_64-unknown-linux-musl.tar.gz -C target/release/ ideavault
 
       - name: Create checksums
         run: sha256sum *.tar.gz > checksums.txt

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ideavault"
-version = "0.1.0"
+version = "0.1.2"
 edition = "2021"
 
 [dependencies]

--- a/install.sh
+++ b/install.sh
@@ -37,7 +37,7 @@ get_download_name() {
     local arch="$2"
     
     if [ "$os" = "linux" ]; then
-        echo "ideavault-${arch}-unknown-linux-gnu.tar.gz"
+        echo "ideavault-${arch}-unknown-linux-musl.tar.gz"
     elif [ "$os" = "macos" ]; then
         echo "ideavault-${arch}-apple-darwin.tar.gz"
     fi


### PR DESCRIPTION
This PR fixes the GLIBC_2.39 compatibility issue by building a statically linked binary using musl libc.

Changes:
- Build with  target for static linking
- Update install.sh to download the musl binary ()
- Bump version to 0.1.2

The statically linked binary will work on older Linux systems without requiring a specific glibc version.