### PR TITLE
fix: simplify docs workflow

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -25,24 +25,8 @@ jobs:
           mkdir -p docs
           cargo run --release -- --markdown-help > docs/CommandLineHelp.md
           
-      - name: Generate Changelog
-        uses: orhun/git-cliff-action@v3
-        with:
-          config: cliff.toml
-          args: --verbose --bump
-        env:
-          OUTPUT: CHANGELOG.md
-          
-      - name: Commit documentation changes
+      - name: Commit CLI documentation
         uses: stefanzweifel/git-auto-commit-action@v5
         with:
-          commit_message: "docs: update documentation for ${{ github.ref_name }} [skip ci]"
-          file_pattern: 'docs/*.md CHANGELOG.md'
-          
-      - name: Update Release Notes
-        uses: softprops/action-gh-release@v2
-        with:
-          body_path: CHANGELOG.md
-          append_body: false
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          commit_message: "docs: update CLI documentation for ${{ github.ref_name }} [skip ci]"
+          file_pattern: 'docs/CommandLineHelp.md'


### PR DESCRIPTION
Simplify documentation workflow by removing problematic git-cliff-action step.

**Problem:**
The git-cliff-action was failing during Docker build.

**Solution:**
- Remove git-cliff-action step
- Keep CLI documentation generation via clap-markdown
- Auto-commit CommandLineHelp.md on tag push

**Testing:**
- Workflow simplified to single responsibility
- Should complete successfully on next tag push

Fixes workflow failures from #8