### PR TITLE
chore: bump version to 0.2.3

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ideavault"
-version = "0.2.0"
+version = "0.2.3"
 edition = "2021"
 
 [dependencies]


### PR DESCRIPTION
## Summary
- Bump version from 0.2.0 to 0.2.3 for next release
- Previous releases (v0.2.1, v0.2.2) were made without updating Cargo.toml

## Context
- Latest tag: v0.2.2
- Cargo.toml was stuck at 0.2.0