### PR TITLE
docs: split ideavault skill into main and release skills

### DIFF
--- a/.opencode/skills/ideavault-release/SKILL.md
+++ b/.opencode/skills/ideavault-release/SKILL.md
@@ -1,0 +1,103 @@
+---
+name: ideavault-release
+description: IdeaVault release process - version bumping, tagging, and monitoring
+license: MIT
+compatibility: opencode
+metadata:
+  project: ideavault
+  language: rust
+  type: release
+---
+
+## Release Process
+
+1. Merge all changes to main via PR
+2. Update version in `Cargo.toml`
+3. Push tag: `git tag vX.Y.Z && git push origin vX.Y.Z`
+4. GitHub Actions automatically:
+   - Builds binary (musl static)
+   - Generates `docs/CommandLineHelp.md`
+   - Creates GitHub release with binary attached
+
+---
+
+## Pre-Release Checklist
+
+Before creating a release:
+
+- [ ] Verify Cargo.toml version is correct (check against existing tags)
+- [ ] `cargo build --release` succeeds
+- [ ] `cargo test` passes
+- [ ] `cargo fmt` applied
+- [ ] `cargo clippy -- -D warnings` clean
+
+### Verify Version
+
+```bash
+# Check current Cargo.toml version
+grep '^version' Cargo.toml | head -1
+
+# Check latest git tag
+git tag --sort=-v:refname | head -5
+
+# Ensure Cargo.toml version > latest tag
+```
+
+---
+
+## Release Commands
+
+```bash
+# 1. Merge PR with version bump to main
+gh pr merge <number> --squash --delete-branch
+
+# 2. Pull latest and create tag
+git checkout main && git pull
+git tag vX.Y.Z && git push origin vX.Y.Z
+
+# 3. Monitor release
+gh run list --limit 3
+gh release view vX.Y.Z
+```
+
+---
+
+## Monitor Release
+
+```bash
+# Check workflow status
+gh run list --limit 3
+
+# View release details
+gh release view vX.Y.Z
+
+# Watch workflow run
+gh run watch
+```
+
+---
+
+## Troubleshooting
+
+### Version Mismatch
+If Cargo.toml version is behind tags:
+1. Create PR to bump version in Cargo.toml
+2. Merge PR
+3. Then proceed with tagging
+
+### Failed Release
+1. Check workflow logs: `gh run view`
+2. Fix issues in new PR
+3. Delete failed tag if needed: `git push --delete origin vX.Y.Z`
+4. Re-tag after fix: `git tag -d vX.Y.Z && git tag vX.Y.Z && git push origin vX.Y.Z`
+
+---
+
+## When to Use This Skill
+
+Use this skill when:
+- Preparing a new release
+- Bumping version numbers
+- Creating and pushing git tags
+- Monitoring GitHub Actions release workflow
+- Troubleshooting release failures

--- a/.opencode/skills/ideavault/SKILL.md
+++ b/.opencode/skills/ideavault/SKILL.md
@@ -1,0 +1,211 @@
+---
+name: ideavault
+description: IdeaVault Rust CLI project conventions, build commands, code style, and git workflow
+license: MIT
+compatibility: opencode
+metadata:
+  project: ideavault
+  language: rust
+  framework: clap
+---
+
+## Project Overview
+
+- **Name**: IdeaVault
+- **Type**: Rust CLI Tool
+- **Description**: A CLI tool for managing ideas, projects, and tasks
+- **Tech Stack**: Rust 2021, clap 4.4, serde, anyhow, chrono, uuid
+
+---
+
+## Build & Test Commands
+
+```bash
+# Build
+cargo build --release
+
+# Run all tests
+cargo test
+
+# Run a single test (by test name)
+cargo test test_name
+
+# Run a single test with exact match
+cargo test --exact test_name
+
+# Run tests in a specific file
+cargo test --test storage_test
+
+# Run tests matching a pattern
+cargo test pattern
+
+# Format code
+cargo fmt
+
+# Lint (treat warnings as errors)
+cargo clippy -- -D warnings
+
+# Run locally
+cargo run -- [args]
+```
+
+---
+
+## Git Workflow (MANDATORY)
+
+### All Changes to Main via PR
+- **NEVER push directly to main**
+- Create feature branch for every change
+- Open PR, get review, merge
+- Only push tags directly (for releases)
+
+### Branch Naming
+- `feature/feature-name`
+- `fix/bug-description`
+- `docs/documentation-topic`
+
+### Commit Messages
+- Use conventional commits: `feat:`, `fix:`, `docs:`, `chore:`
+- Keep commits atomic
+- Reference issue numbers in PR description
+
+---
+
+## Code Style Guidelines
+
+### Imports Ordering
+Group imports in this order, separated by blank lines:
+1. External crates (alphabetically)
+2. Internal crate modules (`use crate::...`)
+
+```rust
+use anyhow::{Context, Result};
+use chrono::{DateTime, Utc};
+use clap::{Args, Subcommand};
+use serde::{Deserialize, Serialize};
+use uuid::Uuid;
+
+use crate::models::{Idea, Priority, Status};
+use crate::storage::Storage;
+```
+
+### Naming Conventions
+- **Types/Structs/Enums**: PascalCase (e.g., `Idea`, `TaskStatus`)
+- **Functions/Methods**: snake_case (e.g., `create_idea`, `get_by_id`)
+- **Variables**: snake_case (e.g., `project_id`, `created_at`)
+- **Constants**: SCREAMING_SNAKE_CASE (e.g., `MAX_TITLE_LENGTH`)
+- **Module names**: snake_case (e.g., `storage`, `task_commands`)
+
+### Struct Derives
+```rust
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Idea {
+    // fields...
+}
+```
+
+### Error Handling
+Use anyhow throughout:
+```rust
+// Use .context() for error messages
+storage.load_ideas().context("Failed to load ideas")?;
+
+// Use anyhow! for custom errors
+anyhow::bail!("Idea with ID {} not found", id);
+
+// Convert Option to Result
+let idea = ideas.iter().find(|i| i.id == id)
+    .ok_or_else(|| anyhow::anyhow!("Idea not found"))?;
+```
+
+### Builder Pattern
+```rust
+impl Idea {
+    pub fn new(title: String) -> Self {
+        Self { id: Uuid::new_v4(), title, /* defaults */ }
+    }
+
+    pub fn with_description(mut self, description: String) -> Self {
+        self.description = Some(description);
+        self
+    }
+}
+
+// Usage:
+let idea = Idea::new(title).with_description(desc);
+```
+
+### Mutable Update Pattern
+Always update `updated_at` when modifying:
+```rust
+pub fn set_status(&mut self, status: Status) {
+    self.status = status;
+    self.updated_at = Utc::now();
+}
+```
+
+### Command Structure
+```rust
+#[derive(Debug, Args)]
+pub struct IdeaCommands {
+    #[command(subcommand)]
+    pub command: IdeaSubcommand,
+}
+
+impl IdeaCommands {
+    pub fn execute(&self, storage: &Storage) -> Result<()> {
+        self.command.execute(storage)
+    }
+}
+```
+
+### Tests
+- Unit tests: in `src/lib.rs` under `#[cfg(test)] mod tests`
+- Integration tests: in `tests/` directory
+- Use `?` operator in test functions returning `Result<()>`
+
+```rust
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_name() -> Result<()> {
+        // test code
+        Ok(())
+    }
+}
+```
+
+---
+
+## Key Files
+
+| File | Purpose |
+|------|---------|
+| src/cli.rs | CLI argument definitions |
+| src/commands/*.rs | Command implementations |
+| src/models/*.rs | Data models |
+| src/storage.rs | JSON file persistence |
+| install.sh | One-liner install script |
+| .github/workflows/*.yml | CI/CD pipelines |
+
+---
+
+## Useful Paths
+
+- Data: `~/.local/share/ideavault/`
+- Binary: `/usr/local/bin/ideavault` (after install)
+- Config: Uses XDG base directories
+
+---
+
+## When to Use This Skill
+
+Use this skill when:
+- Working on the IdeaVault Rust CLI project
+- Need build/test/lint commands
+- Creating or reviewing code for style compliance
+- Setting up PRs
+
+For releases, use the `ideavault-release` skill.


### PR DESCRIPTION
## Summary
- Split `.opencode/skills/ideavault/SKILL.md` into two focused skills:
  - `ideavault`: Build/test commands, code style, git workflow
  - `ideavault-release`: Release process, version bumping, tagging, monitoring
- Release skill includes pre-release checklist, monitor commands, and troubleshooting
- Main skill references release skill for release-specific tasks

## Motivation
Separating concerns makes it easier for agents to load the right context for the task at hand.