### PR TITLE
feat: add --url and --repo flags to project new command

### DIFF
--- a/docs/CommandLineHelp.md
+++ b/docs/CommandLineHelp.md
@@ -199,6 +199,8 @@ Create a new project
 
 * `-d`, `--description <DESCRIPTION>` — Optional description for the project
 * `-m`, `--milestone <MILESTONE>` — Optional milestone for the project
+* `--url <URL>` — Optional URL for the project
+* `--repo <REPO>` — Optional repository for the project
 
 
 

--- a/src/commands/project.rs
+++ b/src/commands/project.rs
@@ -46,6 +46,14 @@ pub struct NewProjectArgs {
     /// Optional milestone for the project
     #[arg(short = 'm', long = "milestone")]
     milestone: Option<String>,
+
+    /// Optional URL for the project
+    #[arg(long = "url")]
+    url: Option<String>,
+
+    /// Optional repository for the project
+    #[arg(long = "repo")]
+    repo: Option<String>,
 }
 
 #[derive(Args)]
@@ -133,6 +141,13 @@ impl ProjectCommands {
 
         if let Some(milestone) = &args.milestone {
             project = project.with_milestone(milestone.clone());
+        }
+
+        if let Some(url) = &args.url {
+            project = project.with_url(url.clone());
+        }
+        if let Some(repo) = &args.repo {
+            project = project.with_repo(repo.clone());
         }
 
         let mut projects = storage.load_projects().context("Failed to load projects")?;
@@ -361,6 +376,12 @@ fn print_project_summary(project: &Project) {
     if let Some(milestone) = &project.milestone {
         println!("   🎯 {}", milestone);
     }
+    if let Some(url) = &project.url {
+        println!("   URL: {}", url);
+    }
+    if let Some(repo) = &project.repo {
+        println!("   Repo: {}", repo);
+    }
     if !project.idea_ids.is_empty() {
         println!("   💡 {} idea(s)", project.idea_ids.len());
     }
@@ -384,6 +405,13 @@ fn print_project_full(project: &Project, ideas: &[Idea]) {
 
     if let Some(milestone) = &project.milestone {
         println!("Milestone: {}", milestone);
+    }
+
+    if let Some(url) = &project.url {
+        println!("  URL: {}", url);
+    }
+    if let Some(repo) = &project.repo {
+        println!("  Repo: {}", repo);
     }
 
     println!("Ideas: {} linked", project.idea_ids.len());

--- a/src/models/project.rs
+++ b/src/models/project.rs
@@ -16,6 +16,8 @@ pub struct Project {
     pub title: String,
     pub description: Option<String>,
     pub milestone: Option<String>,
+    pub url: Option<String>,
+    pub repo: Option<String>,
     pub status: ProjectStatus,
     pub idea_ids: Vec<Uuid>,
     pub created_at: DateTime<Utc>,
@@ -30,6 +32,8 @@ impl Project {
             title,
             description: None,
             milestone: None,
+            url: None,
+            repo: None,
             status: ProjectStatus::Planning,
             idea_ids: Vec::new(),
             created_at: now,
@@ -45,6 +49,18 @@ impl Project {
 
     pub fn with_milestone(mut self, milestone: String) -> Self {
         self.milestone = Some(milestone);
+        self.updated_at = Utc::now();
+        self
+    }
+
+    pub fn with_url(mut self, url: String) -> Self {
+        self.url = Some(url);
+        self.updated_at = Utc::now();
+        self
+    }
+
+    pub fn with_repo(mut self, repo: String) -> Self {
+        self.repo = Some(repo);
         self.updated_at = Utc::now();
         self
     }
@@ -73,6 +89,16 @@ impl Project {
 
     pub fn update_milestone(&mut self, milestone: Option<String>) {
         self.milestone = milestone;
+        self.updated_at = Utc::now();
+    }
+
+    pub fn set_url(&mut self, url: Option<String>) {
+        self.url = url;
+        self.updated_at = Utc::now();
+    }
+
+    pub fn set_repo(&mut self, repo: Option<String>) {
+        self.repo = repo;
         self.updated_at = Utc::now();
     }
 

--- a/tests/project_tests.rs
+++ b/tests/project_tests.rs
@@ -1,0 +1,60 @@
+use ideavault::models::Project;
+
+#[test]
+fn project_url_and_repo_roundtrip() {
+    let project = Project::new("Test Project".to_string())
+        .with_url("https://example.com".to_string())
+        .with_repo("https://github.com/user/repo".to_string());
+
+    assert_eq!(project.url, Some("https://example.com".to_string()));
+    assert_eq!(
+        project.repo,
+        Some("https://github.com/user/repo".to_string())
+    );
+}
+
+#[test]
+fn project_new_without_url_repo() {
+    let project = Project::new("Test".to_string());
+
+    assert_eq!(project.url, None);
+    assert_eq!(project.repo, None);
+}
+
+#[test]
+fn project_set_url() {
+    let mut project = Project::new("Test".to_string());
+    project.set_url(Some("https://example.com".to_string()));
+
+    assert_eq!(project.url, Some("https://example.com".to_string()));
+}
+
+#[test]
+fn project_set_repo() {
+    let mut project = Project::new("Test".to_string());
+    project.set_repo(Some("https://github.com/user/repo".to_string()));
+
+    assert_eq!(
+        project.repo,
+        Some("https://github.com/user/repo".to_string())
+    );
+}
+
+#[test]
+fn project_clear_url() {
+    let mut project = Project::new("Test".to_string()).with_url("https://example.com".to_string());
+
+    project.set_url(None);
+
+    assert_eq!(project.url, None);
+}
+
+#[test]
+fn project_clear_repo() {
+    let mut project =
+        Project::new("Test".to_string()).with_repo("https://github.com/user/repo".to_string());
+
+    project.set_repo(None);
+
+    assert_eq!(project.repo, None);
+}


### PR DESCRIPTION
## Summary
- Add `url` and `repo` optional fields to `Project` model
- Add `--url` and `--repo` CLI flags to `project new` command
- Display url/repo in `project show` output
- Add comprehensive test coverage

## Changes
| File | Changes |
|------|---------|
| `src/models/project.rs` | Added `url`, `repo` fields, builder methods, setter methods |
| `src/commands/project.rs` | Added CLI args, display in show commands |
| `tests/project_tests.rs` | New test file with 6 tests |
| `docs/CommandLineHelp.md` | Regenerated with new flags |

## Usage
```bash
# Create project with URL
ideavault project new "My Project" --url "https://example.com"

# Create project with repo
ideavault project new "My Project" --repo "https://github.com/user/repo"

# Create project with both
ideavault project new "My Project" --url "https://example.com" --repo "https://github.com/user/repo"
```

## Tests
All tests pass:
- `project_url_and_repo_roundtrip`
- `project_new_without_url_repo`
- `project_set_url`
- `project_set_repo`
- `project_clear_url`
- `project_clear_repo`

## Verification
- [x] `cargo fmt --check` passes
- [x] `cargo clippy -- -D warnings` passes
- [x] `cargo test` passes (6 new tests)
- [x] `cargo build --release` succeeds

Closes #11 (superseded by this implementation)