### PR TITLE
feat: add project update command

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -230,6 +230,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "errno"
+version = "0.3.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
+dependencies = [
+ "libc",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "fastrand"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
+
+[[package]]
 name = "find-msvc-tools"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -390,7 +406,7 @@ dependencies = [
 
 [[package]]
 name = "ideavault"
-version = "0.2.3"
+version = "0.2.4"
 dependencies = [
  "anyhow",
  "chrono",
@@ -399,6 +415,7 @@ dependencies = [
  "directories",
  "serde",
  "serde_json",
+ "tempfile",
  "thiserror",
  "ureq",
  "uuid",
@@ -449,9 +466,9 @@ dependencies = [
 
 [[package]]
 name = "libc"
-version = "0.2.181"
+version = "0.2.182"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "459427e2af2b9c839b132acb702a1c654d95e10f8c326bfc2ad11310e458b1c5"
+checksum = "6800badb6cb2082ffd7b6a67e6125bb39f18782f793520caee8cb8846be06112"
 
 [[package]]
 name = "libredox"
@@ -462,6 +479,12 @@ dependencies = [
  "bitflags",
  "libc",
 ]
+
+[[package]]
+name = "linux-raw-sys"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
 
 [[package]]
 name = "litemap"
@@ -580,6 +603,19 @@ dependencies = [
  "libc",
  "untrusted",
  "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "rustix"
+version = "1.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
+dependencies = [
+ "bitflags",
+ "errno",
+ "libc",
+ "linux-raw-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -722,6 +758,19 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "tempfile"
+version = "3.26.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "82a72c767771b47409d2345987fda8628641887d5466101319899796367354a0"
+dependencies = [
+ "fastrand",
+ "getrandom 0.3.4",
+ "once_cell",
+ "rustix",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,3 +14,6 @@ directories = "5.0"
 anyhow = "1.0"
 thiserror = "1.0"
 ureq = { version = "2.9", features = ["json"] }
+
+[dev-dependencies]
+tempfile = "3.8"

--- a/docs/CommandLineHelp.md
+++ b/docs/CommandLineHelp.md
@@ -22,6 +22,7 @@ This document contains the help content for the `ideavault` command-line program
 * [`ideavault project ideas`↴](#ideavault-project-ideas)
 * [`ideavault project status`↴](#ideavault-project-status)
 * [`ideavault project delete`↴](#ideavault-project-delete)
+* [`ideavault project update`↴](#ideavault-project-update)
 * [`ideavault task`↴](#ideavault-task)
 * [`ideavault task new`↴](#ideavault-task-new)
 * [`ideavault task list`↴](#ideavault-task-list)
@@ -184,6 +185,7 @@ Manage projects
 * `ideas` — List all ideas linked to a project
 * `status` — Update the status of a project
 * `delete` — Delete a project with confirmation
+* `update` — Update project fields (title, description, milestone, url, repo, status)
 
 
 
@@ -294,6 +296,28 @@ Delete a project with confirmation
 ###### **Options:**
 
 * `-f`, `--force` — Skip confirmation prompt
+
+
+
+## `ideavault project update`
+
+Update project fields (title, description, milestone, url, repo, status)
+
+**Usage:** `ideavault project update [OPTIONS] <ID>`
+
+###### **Arguments:**
+
+* `<ID>` — Project ID to update
+
+###### **Options:**
+
+* `-t`, `--title <TITLE>` — New title
+* `-d`, `--description <DESCRIPTION>` — New description
+* `-m`, `--milestone <MILESTONE>` — New milestone
+* `--url <URL>` — New URL
+* `--repo <REPO>` — New repository URL
+* `-s`, `--status <STATUS>` — New status
+* `--clear <FIELD>` — Clear one or more optional fields (description, milestone, url, repo)
 
 
 

--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -328,9 +328,44 @@ export EDITOR="emacs"         # Emacs
 | `ideavault project create "name"` | Create a new project |
 | `ideavault project list` | List all projects |
 | `ideavault project show <id>` | Show project with ideas & tasks |
-| `ideavault project update <id> --status InProgress` | Update project |
-| `ideavault project status <id>` | Get project progress summary |
+| `ideavault project update <id> [flags]` | Update project fields |
+| `ideavault project status <id> <status>` | Quick status update |
 | `ideavault project delete <id>` | Delete a project |
+
+#### Updating Projects
+
+Update one or more fields of an existing project:
+
+```bash
+# Update title
+ideavault project update <id> --title "New Title"
+
+# Update multiple fields at once
+ideavault project update <id> --title "New" --url "https://example.com" --milestone "v1.0"
+
+# Clear optional fields
+ideavault project update <id> --clear url --clear milestone
+
+# Mix updates and clears
+ideavault project update <id> --title "Updated" --clear description
+
+# Update status
+ideavault project update <id> --status Active
+```
+
+**Available flags:**
+- `--title` - Project title
+- `--description` - Project description
+- `--milestone` - Current milestone
+- `--url` - Project URL
+- `--repo` - Repository URL
+- `--status` - Project status
+- `--clear <field>` - Clear an optional field (description, milestone, url, repo)
+
+**Quick status update:**
+```bash
+ideavault project status <id> Active
+```
 
 ### Tasks
 

--- a/src/storage.rs
+++ b/src/storage.rs
@@ -23,6 +23,12 @@ impl Storage {
             .context("Failed to get project directories")?;
 
         let data_dir = proj_dirs.data_dir().to_path_buf();
+        Self::new_with_path(data_dir)
+    }
+
+    /// Create storage with a custom data directory path.
+    /// Useful for testing with temporary directories.
+    pub fn new_with_path(data_dir: PathBuf) -> Result<Self> {
         let ideas_file = data_dir.join("ideas.json");
         let projects_file = data_dir.join("projects.json");
         let tags_file = data_dir.join("tags.json");

--- a/tests/project_tests.rs
+++ b/tests/project_tests.rs
@@ -1,4 +1,9 @@
+use ideavault::commands::project::UpdateProjectArgs;
+use ideavault::commands::ProjectCommands;
+use ideavault::models::project::ProjectStatus;
 use ideavault::models::Project;
+use ideavault::storage::Storage;
+use uuid::Uuid;
 
 #[test]
 fn project_url_and_repo_roundtrip() {
@@ -57,4 +62,278 @@ fn project_clear_repo() {
     project.set_repo(None);
 
     assert_eq!(project.repo, None);
+}
+
+#[test]
+fn project_update_title() {
+    let temp_dir = tempfile::tempdir().unwrap();
+    let storage = Storage::new_with_path(temp_dir.path().to_path_buf()).unwrap();
+
+    let project = Project::new("Original Title".to_string());
+    let id = project.id;
+    storage.save_projects(&[project]).unwrap();
+
+    let args = UpdateProjectArgs {
+        id,
+        title: Some("New Title".to_string()),
+        description: None,
+        milestone: None,
+        url: None,
+        repo: None,
+        status: None,
+        clear: vec![],
+    };
+
+    ProjectCommands::update_project(&storage, &args).unwrap();
+
+    let projects = storage.load_projects().unwrap();
+    let updated = projects.iter().find(|p| p.id == id).unwrap();
+    assert_eq!(updated.title, "New Title");
+}
+
+#[test]
+fn project_update_url() {
+    let temp_dir = tempfile::tempdir().unwrap();
+    let storage = Storage::new_with_path(temp_dir.path().to_path_buf()).unwrap();
+
+    let project = Project::new("Test".to_string());
+    let id = project.id;
+    storage.save_projects(&[project]).unwrap();
+
+    let args = UpdateProjectArgs {
+        id,
+        title: None,
+        description: None,
+        milestone: None,
+        url: Some("https://example.com".to_string()),
+        repo: None,
+        status: None,
+        clear: vec![],
+    };
+
+    ProjectCommands::update_project(&storage, &args).unwrap();
+
+    let projects = storage.load_projects().unwrap();
+    let updated = projects.iter().find(|p| p.id == id).unwrap();
+    assert_eq!(updated.url, Some("https://example.com".to_string()));
+}
+
+#[test]
+fn project_update_multiple_fields() {
+    let temp_dir = tempfile::tempdir().unwrap();
+    let storage = Storage::new_with_path(temp_dir.path().to_path_buf()).unwrap();
+
+    let project = Project::new("Original".to_string());
+    let id = project.id;
+    storage.save_projects(&[project]).unwrap();
+
+    let args = UpdateProjectArgs {
+        id,
+        title: Some("New Title".to_string()),
+        description: Some("New description".to_string()),
+        milestone: Some("v1.0".to_string()),
+        url: Some("https://example.com".to_string()),
+        repo: Some("https://github.com/user/repo".to_string()),
+        status: None,
+        clear: vec![],
+    };
+
+    ProjectCommands::update_project(&storage, &args).unwrap();
+
+    let projects = storage.load_projects().unwrap();
+    let updated = projects.iter().find(|p| p.id == id).unwrap();
+    assert_eq!(updated.title, "New Title");
+    assert_eq!(updated.description, Some("New description".to_string()));
+    assert_eq!(updated.milestone, Some("v1.0".to_string()));
+    assert_eq!(updated.url, Some("https://example.com".to_string()));
+    assert_eq!(
+        updated.repo,
+        Some("https://github.com/user/repo".to_string())
+    );
+}
+
+#[test]
+fn project_update_clear_url() {
+    let temp_dir = tempfile::tempdir().unwrap();
+    let storage = Storage::new_with_path(temp_dir.path().to_path_buf()).unwrap();
+
+    let project = Project::new("Test".to_string()).with_url("https://example.com".to_string());
+    let id = project.id;
+    storage.save_projects(&[project]).unwrap();
+
+    let args = UpdateProjectArgs {
+        id,
+        title: None,
+        description: None,
+        milestone: None,
+        url: None,
+        repo: None,
+        status: None,
+        clear: vec!["url".to_string()],
+    };
+
+    ProjectCommands::update_project(&storage, &args).unwrap();
+
+    let projects = storage.load_projects().unwrap();
+    let updated = projects.iter().find(|p| p.id == id).unwrap();
+    assert_eq!(updated.url, None);
+}
+
+#[test]
+fn project_update_clear_multiple() {
+    let temp_dir = tempfile::tempdir().unwrap();
+    let storage = Storage::new_with_path(temp_dir.path().to_path_buf()).unwrap();
+
+    let project = Project::new("Test".to_string())
+        .with_url("https://example.com".to_string())
+        .with_repo("https://github.com/user/repo".to_string())
+        .with_milestone("v1.0".to_string())
+        .with_description("Description".to_string());
+    let id = project.id;
+    storage.save_projects(&[project]).unwrap();
+
+    let args = UpdateProjectArgs {
+        id,
+        title: None,
+        description: None,
+        milestone: None,
+        url: None,
+        repo: None,
+        status: None,
+        clear: vec!["url".to_string(), "repo".to_string()],
+    };
+
+    ProjectCommands::update_project(&storage, &args).unwrap();
+
+    let projects = storage.load_projects().unwrap();
+    let updated = projects.iter().find(|p| p.id == id).unwrap();
+    assert_eq!(updated.url, None);
+    assert_eq!(updated.repo, None);
+    assert_eq!(updated.milestone, Some("v1.0".to_string())); // Not cleared
+}
+
+#[test]
+fn project_update_no_changes() {
+    let temp_dir = tempfile::tempdir().unwrap();
+    let storage = Storage::new_with_path(temp_dir.path().to_path_buf()).unwrap();
+
+    let project = Project::new("Test".to_string());
+    let id = project.id;
+    storage.save_projects(&[project]).unwrap();
+
+    let args = UpdateProjectArgs {
+        id,
+        title: None,
+        description: None,
+        milestone: None,
+        url: None,
+        repo: None,
+        status: None,
+        clear: vec![],
+    };
+
+    // Should succeed but print warning
+    ProjectCommands::update_project(&storage, &args).unwrap();
+}
+
+#[test]
+fn project_update_invalid_id() {
+    let temp_dir = tempfile::tempdir().unwrap();
+    let storage = Storage::new_with_path(temp_dir.path().to_path_buf()).unwrap();
+
+    let args = UpdateProjectArgs {
+        id: Uuid::new_v4(),
+        title: Some("New Title".to_string()),
+        description: None,
+        milestone: None,
+        url: None,
+        repo: None,
+        status: None,
+        clear: vec![],
+    };
+
+    let result = ProjectCommands::update_project(&storage, &args);
+    assert!(result.is_err());
+}
+
+#[test]
+fn project_update_invalid_clear_field() {
+    let temp_dir = tempfile::tempdir().unwrap();
+    let storage = Storage::new_with_path(temp_dir.path().to_path_buf()).unwrap();
+
+    let project = Project::new("Test".to_string());
+    let id = project.id;
+    storage.save_projects(&[project]).unwrap();
+
+    let args = UpdateProjectArgs {
+        id,
+        title: None,
+        description: None,
+        milestone: None,
+        url: None,
+        repo: None,
+        status: None,
+        clear: vec!["invalid_field".to_string()],
+    };
+
+    let result = ProjectCommands::update_project(&storage, &args);
+    assert!(result.is_err());
+}
+
+#[test]
+fn project_update_status() {
+    let temp_dir = tempfile::tempdir().unwrap();
+    let storage = Storage::new_with_path(temp_dir.path().to_path_buf()).unwrap();
+
+    let project = Project::new("Test".to_string());
+    let id = project.id;
+    storage.save_projects(&[project]).unwrap();
+
+    let args = UpdateProjectArgs {
+        id,
+        title: None,
+        description: None,
+        milestone: None,
+        url: None,
+        repo: None,
+        status: Some(ProjectStatus::InProgress),
+        clear: vec![],
+    };
+
+    ProjectCommands::update_project(&storage, &args).unwrap();
+
+    let projects = storage.load_projects().unwrap();
+    let updated = projects.iter().find(|p| p.id == id).unwrap();
+    assert_eq!(updated.status, ProjectStatus::InProgress);
+}
+
+#[test]
+fn project_update_mix_set_and_clear() {
+    let temp_dir = tempfile::tempdir().unwrap();
+    let storage = Storage::new_with_path(temp_dir.path().to_path_buf()).unwrap();
+
+    let project = Project::new("Test".to_string())
+        .with_url("https://old.com".to_string())
+        .with_description("Old description".to_string());
+    let id = project.id;
+    storage.save_projects(&[project]).unwrap();
+
+    let args = UpdateProjectArgs {
+        id,
+        title: Some("New Title".to_string()),
+        description: None,
+        milestone: None,
+        url: Some("https://new.com".to_string()),
+        repo: None,
+        status: None,
+        clear: vec!["description".to_string()],
+    };
+
+    ProjectCommands::update_project(&storage, &args).unwrap();
+
+    let projects = storage.load_projects().unwrap();
+    let updated = projects.iter().find(|p| p.id == id).unwrap();
+    assert_eq!(updated.title, "New Title");
+    assert_eq!(updated.url, Some("https://new.com".to_string()));
+    assert_eq!(updated.description, None);
 }


### PR DESCRIPTION
## Summary
- Add `project update` command to modify existing projects
- Support updating title, description, milestone, url, repo, and status
- Add `--clear <field>` flag to clear optional fields
- Keep existing `project status` command for backwards compatibility

## Usage
```bash
# Update single field
ideavault project update <id> --title "New Title"

# Update multiple fields
ideavault project update <id> --title "New" --url "https://example.com" --milestone "v1.0"

# Clear optional fields
ideavault project update <id> --clear url --clear milestone

# Mix updates and clears
ideavault project update <id> --title "Updated" --clear description

# Update status
ideavault project update <id> --status Active
```

## Changes
| File | Changes |
|------|---------|
| `src/commands/project.rs` | Add Update variant, UpdateProjectArgs, update_project() |
| `src/storage.rs` | Add Storage::new_with_path() for test isolation |
| `tests/project_tests.rs` | Add 10 new tests |
| `docs/USAGE.md` | Add update command examples |
| `docs/CommandLineHelp.md` | Regenerated |

## Tests
All 23 tests pass:
- `project_update_title`
- `project_update_url`
- `project_update_multiple_fields`
- `project_update_clear_url`
- `project_update_clear_multiple`
- `project_update_no_changes`
- `project_update_invalid_id`
- `project_update_invalid_clear_field`
- `project_update_status`
- `project_update_mix_set_and_clear`

## Verification
- [x] `cargo fmt --check` passes
- [x] `cargo clippy -- -D warnings` passes
- [x] `cargo test` passes (23 tests)
- [x] `cargo build --release` succeeds
- [x] Manual testing verified

## Design Decisions
1. **`--clear` flag pattern** - Follows stream-cli pattern for explicit, discoverable clearing
2. **Keep `project status` command** - Backwards compatibility, quick single-field updates
3. **Change summary output** - Shows what changed: `title: "Old" → "New"`
4. **No changes message** - Friendly message when no flags provided