### PR TITLE
feat: add idea update command

### DIFF
--- a/docs/CommandLineHelp.md
+++ b/docs/CommandLineHelp.md
@@ -13,6 +13,7 @@ This document contains the help content for the `ideavault` command-line program
 * [`ideavault idea status`↴](#ideavault-idea-status)
 * [`ideavault idea edit`↴](#ideavault-idea-edit)
 * [`ideavault idea delete`↴](#ideavault-idea-delete)
+* [`ideavault idea update`↴](#ideavault-idea-update)
 * [`ideavault project`↴](#ideavault-project)
 * [`ideavault project new`↴](#ideavault-project-new)
 * [`ideavault project list`↴](#ideavault-project-list)
@@ -70,6 +71,7 @@ Manage ideas
 * `status` — Update the status of an idea
 * `edit` — Edit an idea in $EDITOR
 * `delete` — Delete an idea with confirmation
+* `update` — Update idea fields (title, description, status)
 
 
 
@@ -166,6 +168,25 @@ Delete an idea with confirmation
 ###### **Options:**
 
 * `-f`, `--force` — Skip confirmation prompt
+
+
+
+## `ideavault idea update`
+
+Update idea fields (title, description, status)
+
+**Usage:** `ideavault idea update [OPTIONS] <ID>`
+
+###### **Arguments:**
+
+* `<ID>` — Idea ID to update
+
+###### **Options:**
+
+* `-t`, `--title <TITLE>` — New title
+* `-d`, `--description <DESCRIPTION>` — New description
+* `-s`, `--status <STATUS>` — New status
+* `--clear <FIELD>` — Clear one or more optional fields (description)
 
 
 

--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -324,10 +324,38 @@ export EDITOR="emacs"         # Emacs
 | `ideavault idea list --status Active` | List ideas by status |
 | `ideavault idea list --tag <tag>` | List ideas by tag |
 | `ideavault idea show <id>` | Show idea details |
-| `ideavault idea status <id> <status>` | Update idea status |
+| `ideavault idea update <id> [flags]` | Update idea fields |
+| `ideavault idea status <id> <status>` | Quick status update |
 | `ideavault idea tag <id> <tags...>` | Update idea tags |
 | `ideavault idea edit <id>` | Edit idea in $EDITOR |
 | `ideavault idea delete <id>` | Delete an idea |
+
+#### Updating Ideas
+
+Update one or more fields of an existing idea:
+
+```bash
+# Update title
+ideavault idea update <id> --title "New Title"
+
+# Update description
+ideavault idea update <id> --description "New description"
+
+# Update status
+ideavault idea update <id> --status Active
+
+# Update multiple fields at once
+ideavault idea update <id> --title "New" --description "Updated description"
+
+# Clear optional fields
+ideavault idea update <id> --clear description
+```
+
+**Available flags:**
+- `--title` - Idea title
+- `--description` - Idea description
+- `--status` - Idea status (Brainstorming, Active, Completed, Archived)
+- `--clear <field>` - Clear an optional field (description)
 
 ### Projects
 
@@ -395,6 +423,7 @@ ideavault project status <id> InProgress
 | `ideavault task status <id> <status>` | Update task status |
 | `ideavault task priority <id> <priority>` | Update task priority |
 | `ideavault task due <id> <date>` | Set due date |
+| `ideavault task update <id> [flags]` | Update task fields |
 | `ideavault task link-project <task-id> <project-id>` | Link task to project |
 | `ideavault task link-idea <task-id> <idea-id>` | Link task to idea |
 | `ideavault task edit <id>` | Edit task in $EDITOR |

--- a/tests/idea_tests.rs
+++ b/tests/idea_tests.rs
@@ -1,0 +1,210 @@
+use ideavault::commands::idea::{IdeaCommands, IdeaUpdateArgs};
+use ideavault::models::idea::{Idea, IdeaStatus};
+use ideavault::storage::Storage;
+use uuid::Uuid;
+
+#[test]
+fn idea_update_title() {
+    let temp_dir = tempfile::tempdir().unwrap();
+    let storage = Storage::new_with_path(temp_dir.path().to_path_buf()).unwrap();
+
+    let idea = Idea::new("Original Title".to_string());
+    let id = idea.id;
+    storage.save_ideas(&[idea]).unwrap();
+
+    let args = IdeaUpdateArgs {
+        id,
+        title: Some("New Title".to_string()),
+        description: None,
+        status: None,
+        clear: vec![],
+    };
+
+    IdeaCommands::update_idea(&storage, &args).unwrap();
+
+    let ideas = storage.load_ideas().unwrap();
+    let updated = ideas.iter().find(|i| i.id == id).unwrap();
+    assert_eq!(updated.title, "New Title");
+}
+
+#[test]
+fn idea_update_description() {
+    let temp_dir = tempfile::tempdir().unwrap();
+    let storage = Storage::new_with_path(temp_dir.path().to_path_buf()).unwrap();
+
+    let idea = Idea::new("Test".to_string());
+    let id = idea.id;
+    storage.save_ideas(&[idea]).unwrap();
+
+    let args = IdeaUpdateArgs {
+        id,
+        title: None,
+        description: Some("New description".to_string()),
+        status: None,
+        clear: vec![],
+    };
+
+    IdeaCommands::update_idea(&storage, &args).unwrap();
+
+    let ideas = storage.load_ideas().unwrap();
+    let updated = ideas.iter().find(|i| i.id == id).unwrap();
+    assert_eq!(updated.description, Some("New description".to_string()));
+}
+
+#[test]
+fn idea_update_multiple_fields() {
+    let temp_dir = tempfile::tempdir().unwrap();
+    let storage = Storage::new_with_path(temp_dir.path().to_path_buf()).unwrap();
+
+    let idea = Idea::new("Original".to_string());
+    let id = idea.id;
+    storage.save_ideas(&[idea]).unwrap();
+
+    let args = IdeaUpdateArgs {
+        id,
+        title: Some("New Title".to_string()),
+        description: Some("New description".to_string()),
+        status: Some(IdeaStatus::Active),
+        clear: vec![],
+    };
+
+    IdeaCommands::update_idea(&storage, &args).unwrap();
+
+    let ideas = storage.load_ideas().unwrap();
+    let updated = ideas.iter().find(|i| i.id == id).unwrap();
+    assert_eq!(updated.title, "New Title");
+    assert_eq!(updated.description, Some("New description".to_string()));
+    assert_eq!(updated.status, IdeaStatus::Active);
+}
+
+#[test]
+fn idea_update_clear_description() {
+    let temp_dir = tempfile::tempdir().unwrap();
+    let storage = Storage::new_with_path(temp_dir.path().to_path_buf()).unwrap();
+
+    let idea = Idea::new("Test".to_string()).with_description("Original description".to_string());
+    let id = idea.id;
+    storage.save_ideas(&[idea]).unwrap();
+
+    let args = IdeaUpdateArgs {
+        id,
+        title: None,
+        description: None,
+        status: None,
+        clear: vec!["description".to_string()],
+    };
+
+    IdeaCommands::update_idea(&storage, &args).unwrap();
+
+    let ideas = storage.load_ideas().unwrap();
+    let updated = ideas.iter().find(|i| i.id == id).unwrap();
+    assert_eq!(updated.description, None);
+}
+
+#[test]
+fn idea_update_no_changes() {
+    let temp_dir = tempfile::tempdir().unwrap();
+    let storage = Storage::new_with_path(temp_dir.path().to_path_buf()).unwrap();
+
+    let idea = Idea::new("Test".to_string());
+    let id = idea.id;
+    storage.save_ideas(&[idea]).unwrap();
+
+    let args = IdeaUpdateArgs {
+        id,
+        title: None,
+        description: None,
+        status: None,
+        clear: vec![],
+    };
+
+    // Should succeed but print warning
+    IdeaCommands::update_idea(&storage, &args).unwrap();
+}
+
+#[test]
+fn idea_update_invalid_id() {
+    let temp_dir = tempfile::tempdir().unwrap();
+    let storage = Storage::new_with_path(temp_dir.path().to_path_buf()).unwrap();
+
+    let args = IdeaUpdateArgs {
+        id: Uuid::new_v4(),
+        title: Some("New Title".to_string()),
+        description: None,
+        status: None,
+        clear: vec![],
+    };
+
+    let result = IdeaCommands::update_idea(&storage, &args);
+    assert!(result.is_err());
+}
+
+#[test]
+fn idea_update_invalid_clear_field() {
+    let temp_dir = tempfile::tempdir().unwrap();
+    let storage = Storage::new_with_path(temp_dir.path().to_path_buf()).unwrap();
+
+    let idea = Idea::new("Test".to_string());
+    let id = idea.id;
+    storage.save_ideas(&[idea]).unwrap();
+
+    let args = IdeaUpdateArgs {
+        id,
+        title: None,
+        description: None,
+        status: None,
+        clear: vec!["invalid_field".to_string()],
+    };
+
+    let result = IdeaCommands::update_idea(&storage, &args);
+    assert!(result.is_err());
+}
+
+#[test]
+fn idea_update_status() {
+    let temp_dir = tempfile::tempdir().unwrap();
+    let storage = Storage::new_with_path(temp_dir.path().to_path_buf()).unwrap();
+
+    let idea = Idea::new("Test".to_string());
+    let id = idea.id;
+    storage.save_ideas(&[idea]).unwrap();
+
+    let args = IdeaUpdateArgs {
+        id,
+        title: None,
+        description: None,
+        status: Some(IdeaStatus::Completed),
+        clear: vec![],
+    };
+
+    IdeaCommands::update_idea(&storage, &args).unwrap();
+
+    let ideas = storage.load_ideas().unwrap();
+    let updated = ideas.iter().find(|i| i.id == id).unwrap();
+    assert_eq!(updated.status, IdeaStatus::Completed);
+}
+
+#[test]
+fn idea_update_mix_set_and_clear() {
+    let temp_dir = tempfile::tempdir().unwrap();
+    let storage = Storage::new_with_path(temp_dir.path().to_path_buf()).unwrap();
+
+    let idea = Idea::new("Test".to_string()).with_description("Old description".to_string());
+    let id = idea.id;
+    storage.save_ideas(&[idea]).unwrap();
+
+    let args = IdeaUpdateArgs {
+        id,
+        title: Some("New Title".to_string()),
+        description: None,
+        status: None,
+        clear: vec!["description".to_string()],
+    };
+
+    IdeaCommands::update_idea(&storage, &args).unwrap();
+
+    let ideas = storage.load_ideas().unwrap();
+    let updated = ideas.iter().find(|i| i.id == id).unwrap();
+    assert_eq!(updated.title, "New Title");
+    assert_eq!(updated.description, None);
+}


### PR DESCRIPTION
## Summary

Implements the `idea update` command as described in GitHub issue #21.

## Changes

- Added `IdeaUpdateArgs` struct with support for:
  - `--title` / `-t` - Update idea title
  - `--description` / `-d` - Update idea description
  - `--status` / `-s` - Update idea status
  - `--clear` - Clear optional fields (description)
- Added `Update` variant to `IdeaSubcommand` enum
- Implemented `update_idea()` function following the existing `project update` pattern
- Added 9 unit tests for idea update functionality
- Updated `docs/USAGE.md` with idea update examples
- Regenerated `docs/CommandLineHelp.md`

## Verification

- All tests pass (9 new idea update tests + existing tests)
- `cargo fmt` applied
- `cargo clippy` passes with no warnings

## Notes

- Uses existing model methods: `update_title()`, `update_description()`, `set_status()`
- Follows same pattern as `project update` command
- The function is public to allow testing