### PR TITLE
feat: add task update command

### DIFF
--- a/docs/CommandLineHelp.md
+++ b/docs/CommandLineHelp.md
@@ -36,6 +36,7 @@ This document contains the help content for the `ideavault` command-line program
 * [`ideavault task unlink-idea`↴](#ideavault-task-unlink-idea)
 * [`ideavault task edit`↴](#ideavault-task-edit)
 * [`ideavault task delete`↴](#ideavault-task-delete)
+* [`ideavault task update`↴](#ideavault-task-update)
 * [`ideavault search`↴](#ideavault-search)
 * [`ideavault version`↴](#ideavault-version)
 
@@ -341,6 +342,7 @@ Manage tasks
 * `unlink-idea` — Unlink task from idea
 * `edit` — Edit a task in $EDITOR
 * `delete` — Delete a task with confirmation
+* `update` — 
 
 
 
@@ -508,6 +510,26 @@ Delete a task with confirmation
 ###### **Options:**
 
 * `-f`, `--force` — Skip confirmation prompt
+
+
+
+## `ideavault task update`
+
+**Usage:** `ideavault task update [OPTIONS] <ID>`
+
+###### **Arguments:**
+
+* `<ID>` — Task ID to update
+
+###### **Options:**
+
+* `-t`, `--title <TITLE>` — New title
+* `-d`, `--description <DESCRIPTION>` — New description
+* `-p`, `--priority <PRIORITY>` — New priority (low|medium|high|urgent)
+* `-D`, `--due <DUE_DATE>` — New due date (YYYY-MM-DD format) or "clear" to remove
+* `-s`, `--status <STATUS>` — New status (todo|inprogress|blocked|done|cancelled)
+* `-g`, `--tags <TAGS>` — New tags (comma-separated, replaces existing tags)
+* `--clear <FIELD>` — Clear one or more optional fields (description, due_date, tags)
 
 
 

--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -395,10 +395,47 @@ ideavault project status <id> InProgress
 | `ideavault task status <id> <status>` | Update task status |
 | `ideavault task priority <id> <priority>` | Update task priority |
 | `ideavault task due <id> <date>` | Set due date |
+| `ideavault task update <id> [flags]` | Update task fields |
 | `ideavault task link-project <task-id> <project-id>` | Link task to project |
 | `ideavault task link-idea <task-id> <idea-id>` | Link task to idea |
 | `ideavault task edit <id>` | Edit task in $EDITOR |
 | `ideavault task delete <id>` | Delete a task |
+
+#### Updating Tasks
+
+Update one or more fields of an existing task:
+
+```bash
+# Update title
+ideavault task update <id> --title "New Title"
+
+# Update multiple fields at once
+ideavault task update <id> --title "Updated" --priority high --status inprogress
+
+# Update due date
+ideavault task update <id> --due 2024-02-15
+
+# Clear due date
+ideavault task update <id> --due clear
+
+# Clear optional fields
+ideavault task update <id> --clear description --clear tags
+
+# Update tags (replaces existing tags)
+ideavault task update <id> --tags "work,urgent"
+
+# Mix updates and clears
+ideavault task update <id> --title "Updated" --clear due_date
+```
+
+**Available flags:**
+- `--title` - Task title
+- `--description` - Task description
+- `--priority` - Task priority (low|medium|high|urgent)
+- `--due` - Due date (YYYY-MM-DD format) or "clear" to remove
+- `--status` - Task status (todo|inprogress|blocked|done|cancelled)
+- `--tags` - Tags (comma-separated, replaces existing tags)
+- `--clear <field>` - Clear an optional field (description, due_date, tags)
 
 ### Search
 

--- a/src/models/task.rs
+++ b/src/models/task.rs
@@ -93,6 +93,42 @@ impl Task {
         self.updated_at = Utc::now();
         self
     }
+
+    /// Update the title of the task
+    pub fn update_title(&mut self, title: String) {
+        self.title = title;
+        self.updated_at = Utc::now();
+    }
+
+    /// Update the description of the task
+    pub fn update_description(&mut self, description: Option<String>) {
+        self.description = description;
+        self.updated_at = Utc::now();
+    }
+
+    /// Set the priority of the task
+    pub fn set_priority(&mut self, priority: TaskPriority) {
+        self.priority = priority;
+        self.updated_at = Utc::now();
+    }
+
+    /// Set the due date of the task
+    pub fn set_due_date(&mut self, due_date: Option<DateTime<Utc>>) {
+        self.due_date = due_date;
+        self.updated_at = Utc::now();
+    }
+
+    /// Set the status of the task
+    pub fn set_status(&mut self, status: TaskStatus) {
+        self.status = status;
+        self.updated_at = Utc::now();
+    }
+
+    /// Update tags for the task
+    pub fn update_tags(&mut self, tags: Vec<String>) {
+        self.tags = tags;
+        self.updated_at = Utc::now();
+    }
 }
 
 impl std::str::FromStr for TaskStatus {

--- a/tests/task_tests.rs
+++ b/tests/task_tests.rs
@@ -1,0 +1,414 @@
+use ideavault::commands::task::{TaskCommands, TaskUpdateArgs};
+use ideavault::models::task::{Task, TaskPriority, TaskStatus};
+use ideavault::storage::Storage;
+
+#[test]
+fn task_update_title() {
+    let temp_dir = tempfile::tempdir().unwrap();
+    let storage = Storage::new_with_path(temp_dir.path().to_path_buf()).unwrap();
+
+    let task = Task::new("Original Title".to_string());
+    let id = task.id;
+    storage.save_tasks(&[task]).unwrap();
+
+    let args = TaskUpdateArgs {
+        id,
+        title: Some("New Title".to_string()),
+        description: None,
+        priority: None,
+        due_date: None,
+        status: None,
+        tags: None,
+        clear: vec![],
+    };
+
+    TaskCommands::update_task(&storage, &args).unwrap();
+
+    let tasks = storage.load_tasks().unwrap();
+    let updated = tasks.iter().find(|t| t.id == id).unwrap();
+    assert_eq!(updated.title, "New Title");
+}
+
+#[test]
+fn task_update_description() {
+    let temp_dir = tempfile::tempdir().unwrap();
+    let storage = Storage::new_with_path(temp_dir.path().to_path_buf()).unwrap();
+
+    let task = Task::new("Test".to_string());
+    let id = task.id;
+    storage.save_tasks(&[task]).unwrap();
+
+    let args = TaskUpdateArgs {
+        id,
+        title: None,
+        description: Some("New description".to_string()),
+        priority: None,
+        due_date: None,
+        status: None,
+        tags: None,
+        clear: vec![],
+    };
+
+    TaskCommands::update_task(&storage, &args).unwrap();
+
+    let tasks = storage.load_tasks().unwrap();
+    let updated = tasks.iter().find(|t| t.id == id).unwrap();
+    assert_eq!(updated.description, Some("New description".to_string()));
+}
+
+#[test]
+fn task_update_priority() {
+    let temp_dir = tempfile::tempdir().unwrap();
+    let storage = Storage::new_with_path(temp_dir.path().to_path_buf()).unwrap();
+
+    let task = Task::new("Test".to_string());
+    let id = task.id;
+    storage.save_tasks(&[task]).unwrap();
+
+    let args = TaskUpdateArgs {
+        id,
+        title: None,
+        description: None,
+        priority: Some(TaskPriority::High),
+        due_date: None,
+        status: None,
+        tags: None,
+        clear: vec![],
+    };
+
+    TaskCommands::update_task(&storage, &args).unwrap();
+
+    let tasks = storage.load_tasks().unwrap();
+    let updated = tasks.iter().find(|t| t.id == id).unwrap();
+    assert_eq!(updated.priority, TaskPriority::High);
+}
+
+#[test]
+fn task_update_due_date() {
+    let temp_dir = tempfile::tempdir().unwrap();
+    let storage = Storage::new_with_path(temp_dir.path().to_path_buf()).unwrap();
+
+    let task = Task::new("Test".to_string());
+    let id = task.id;
+    storage.save_tasks(&[task]).unwrap();
+
+    let args = TaskUpdateArgs {
+        id,
+        title: None,
+        description: None,
+        priority: None,
+        due_date: Some("2024-12-31".to_string()),
+        status: None,
+        tags: None,
+        clear: vec![],
+    };
+
+    TaskCommands::update_task(&storage, &args).unwrap();
+
+    let tasks = storage.load_tasks().unwrap();
+    let updated = tasks.iter().find(|t| t.id == id).unwrap();
+    assert!(updated.due_date.is_some());
+    assert_eq!(
+        updated.due_date.unwrap().format("%Y-%m-%d").to_string(),
+        "2024-12-31"
+    );
+}
+
+#[test]
+fn task_update_status() {
+    let temp_dir = tempfile::tempdir().unwrap();
+    let storage = Storage::new_with_path(temp_dir.path().to_path_buf()).unwrap();
+
+    let task = Task::new("Test".to_string());
+    let id = task.id;
+    storage.save_tasks(&[task]).unwrap();
+
+    let args = TaskUpdateArgs {
+        id,
+        title: None,
+        description: None,
+        priority: None,
+        due_date: None,
+        status: Some(TaskStatus::InProgress),
+        tags: None,
+        clear: vec![],
+    };
+
+    TaskCommands::update_task(&storage, &args).unwrap();
+
+    let tasks = storage.load_tasks().unwrap();
+    let updated = tasks.iter().find(|t| t.id == id).unwrap();
+    assert_eq!(updated.status, TaskStatus::InProgress);
+}
+
+#[test]
+fn task_update_tags() {
+    let temp_dir = tempfile::tempdir().unwrap();
+    let storage = Storage::new_with_path(temp_dir.path().to_path_buf()).unwrap();
+
+    let task =
+        Task::new("Test".to_string()).with_tags(vec!["old1".to_string(), "old2".to_string()]);
+    let id = task.id;
+    storage.save_tasks(&[task]).unwrap();
+
+    let args = TaskUpdateArgs {
+        id,
+        title: None,
+        description: None,
+        priority: None,
+        due_date: None,
+        status: None,
+        tags: Some(vec!["new1".to_string(), "new2".to_string()]),
+        clear: vec![],
+    };
+
+    TaskCommands::update_task(&storage, &args).unwrap();
+
+    let tasks = storage.load_tasks().unwrap();
+    let updated = tasks.iter().find(|t| t.id == id).unwrap();
+    assert_eq!(updated.tags, vec!["new1", "new2"]);
+}
+
+#[test]
+fn task_update_multiple_fields() {
+    let temp_dir = tempfile::tempdir().unwrap();
+    let storage = Storage::new_with_path(temp_dir.path().to_path_buf()).unwrap();
+
+    let task = Task::new("Original".to_string());
+    let id = task.id;
+    storage.save_tasks(&[task]).unwrap();
+
+    let args = TaskUpdateArgs {
+        id,
+        title: Some("New Title".to_string()),
+        description: Some("New description".to_string()),
+        priority: Some(TaskPriority::Urgent),
+        due_date: None,
+        status: Some(TaskStatus::Done),
+        tags: None,
+        clear: vec![],
+    };
+
+    TaskCommands::update_task(&storage, &args).unwrap();
+
+    let tasks = storage.load_tasks().unwrap();
+    let updated = tasks.iter().find(|t| t.id == id).unwrap();
+    assert_eq!(updated.title, "New Title");
+    assert_eq!(updated.description, Some("New description".to_string()));
+    assert_eq!(updated.priority, TaskPriority::Urgent);
+    assert_eq!(updated.status, TaskStatus::Done);
+}
+
+#[test]
+fn task_update_clear_due_date() {
+    let temp_dir = tempfile::tempdir().unwrap();
+    let storage = Storage::new_with_path(temp_dir.path().to_path_buf()).unwrap();
+
+    let task = Task::new("Test".to_string());
+    let id = task.id;
+    storage.save_tasks(&[task]).unwrap();
+
+    // First set a due date
+    let args_set_due = TaskUpdateArgs {
+        id,
+        title: None,
+        description: None,
+        priority: None,
+        due_date: Some("2024-12-31".to_string()),
+        status: None,
+        tags: None,
+        clear: vec![],
+    };
+    TaskCommands::update_task(&storage, &args_set_due).unwrap();
+
+    // Now clear it
+    let args_clear_due = TaskUpdateArgs {
+        id,
+        title: None,
+        description: None,
+        priority: None,
+        due_date: None,
+        status: None,
+        tags: None,
+        clear: vec!["due_date".to_string()],
+    };
+    TaskCommands::update_task(&storage, &args_clear_due).unwrap();
+
+    let tasks = storage.load_tasks().unwrap();
+    let updated = tasks.iter().find(|t| t.id == id).unwrap();
+    assert!(updated.due_date.is_none());
+}
+
+#[test]
+fn task_update_clear_description() {
+    let temp_dir = tempfile::tempdir().unwrap();
+    let storage = Storage::new_with_path(temp_dir.path().to_path_buf()).unwrap();
+
+    let task = Task::new("Test".to_string()).with_description("Has description".to_string());
+    let id = task.id;
+    storage.save_tasks(&[task]).unwrap();
+
+    let args = TaskUpdateArgs {
+        id,
+        title: None,
+        description: None,
+        priority: None,
+        due_date: None,
+        status: None,
+        tags: None,
+        clear: vec!["description".to_string()],
+    };
+
+    TaskCommands::update_task(&storage, &args).unwrap();
+
+    let tasks = storage.load_tasks().unwrap();
+    let updated = tasks.iter().find(|t| t.id == id).unwrap();
+    assert!(updated.description.is_none());
+}
+
+#[test]
+fn task_update_clear_tags() {
+    let temp_dir = tempfile::tempdir().unwrap();
+    let storage = Storage::new_with_path(temp_dir.path().to_path_buf()).unwrap();
+
+    let task =
+        Task::new("Test".to_string()).with_tags(vec!["tag1".to_string(), "tag2".to_string()]);
+    let id = task.id;
+    storage.save_tasks(&[task]).unwrap();
+
+    let args = TaskUpdateArgs {
+        id,
+        title: None,
+        description: None,
+        priority: None,
+        due_date: None,
+        status: None,
+        tags: None,
+        clear: vec!["tags".to_string()],
+    };
+
+    TaskCommands::update_task(&storage, &args).unwrap();
+
+    let tasks = storage.load_tasks().unwrap();
+    let updated = tasks.iter().find(|t| t.id == id).unwrap();
+    assert!(updated.tags.is_empty());
+}
+
+#[test]
+fn task_update_clear_due_date_via_value() {
+    let temp_dir = tempfile::tempdir().unwrap();
+    let storage = Storage::new_with_path(temp_dir.path().to_path_buf()).unwrap();
+
+    let task = Task::new("Test".to_string());
+    let id = task.id;
+    storage.save_tasks(&[task]).unwrap();
+
+    let args = TaskUpdateArgs {
+        id,
+        title: None,
+        description: None,
+        priority: None,
+        due_date: Some("clear".to_string()),
+        status: None,
+        tags: None,
+        clear: vec![],
+    };
+
+    TaskCommands::update_task(&storage, &args).unwrap();
+
+    let tasks = storage.load_tasks().unwrap();
+    let updated = tasks.iter().find(|t| t.id == id).unwrap();
+    assert!(updated.due_date.is_none());
+}
+
+#[test]
+fn task_update_no_changes() {
+    let temp_dir = tempfile::tempdir().unwrap();
+    let storage = Storage::new_with_path(temp_dir.path().to_path_buf()).unwrap();
+
+    let task = Task::new("Test".to_string());
+    let id = task.id;
+    storage.save_tasks(&[task]).unwrap();
+
+    let args = TaskUpdateArgs {
+        id,
+        title: None,
+        description: None,
+        priority: None,
+        due_date: None,
+        status: None,
+        tags: None,
+        clear: vec![],
+    };
+
+    // Should succeed but print warning
+    TaskCommands::update_task(&storage, &args).unwrap();
+}
+
+#[test]
+fn task_update_invalid_id() {
+    let temp_dir = tempfile::tempdir().unwrap();
+    let storage = Storage::new_with_path(temp_dir.path().to_path_buf()).unwrap();
+
+    let args = TaskUpdateArgs {
+        id: uuid::Uuid::new_v4(),
+        title: Some("New Title".to_string()),
+        description: None,
+        priority: None,
+        due_date: None,
+        status: None,
+        tags: None,
+        clear: vec![],
+    };
+
+    let result = TaskCommands::update_task(&storage, &args);
+    assert!(result.is_err());
+}
+
+#[test]
+fn task_update_invalid_clear_field() {
+    let temp_dir = tempfile::tempdir().unwrap();
+    let storage = Storage::new_with_path(temp_dir.path().to_path_buf()).unwrap();
+
+    let task = Task::new("Test".to_string());
+    let id = task.id;
+    storage.save_tasks(&[task]).unwrap();
+
+    let args = TaskUpdateArgs {
+        id,
+        title: None,
+        description: None,
+        priority: None,
+        due_date: None,
+        status: None,
+        tags: None,
+        clear: vec!["invalid_field".to_string()],
+    };
+
+    let result = TaskCommands::update_task(&storage, &args);
+    assert!(result.is_err());
+}
+
+#[test]
+fn task_update_invalid_date_format() {
+    let temp_dir = tempfile::tempdir().unwrap();
+    let storage = Storage::new_with_path(temp_dir.path().to_path_buf()).unwrap();
+
+    let task = Task::new("Test".to_string());
+    let id = task.id;
+    storage.save_tasks(&[task]).unwrap();
+
+    let args = TaskUpdateArgs {
+        id,
+        title: None,
+        description: None,
+        priority: None,
+        due_date: Some("invalid-date".to_string()),
+        status: None,
+        tags: None,
+        clear: vec![],
+    };
+
+    let result = TaskCommands::update_task(&storage, &args);
+    assert!(result.is_err());
+}


### PR DESCRIPTION
## Summary

- Implements the `task update` command as specified in issue #22
- Follows the existing `project update` command pattern
- Supports updating title, description, priority, due date, status, and tags
- Supports clearing optional fields with `--clear` flag

## Changes

- Added `TaskUpdateArgs` struct to `src/commands/task.rs`
- Added `Update` variant to `TaskSubcommand` enum
- Implemented `update_task()` function
- Added model methods to `src/models/task.rs`:
  - `update_title`
  - `update_description`
  - `set_priority`
  - `set_due_date`
  - `set_status`
  - `update_tags`
- Added 15 unit tests in `tests/task_tests.rs`
- Updated `docs/USAGE.md` with task update examples
- Regenerated `docs/CommandLineHelp.md`

## Verification

- `cargo build --release` ✓
- `cargo fmt` ✓
- `cargo clippy -- -D warnings` ✓
- `cargo test` (47 tests passing) ✓